### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#AutoCompleteTextView
+# AutoCompleteTextView
 ### KMP Algorithm
 
 * 自动补全TextView
@@ -21,5 +21,5 @@
 ![](https://github.com/andyxialm/KMPAutoCompleteTextView/blob/master/art/Screenshot_sample.png?raw=true)
 
 
-#License
+# License
 <p>KMPAutoCompleteTextView is available under the MIT license.</p>


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
